### PR TITLE
HOME-128 - Add external 'proxy' command

### DIFF
--- a/cmdapi/cmdapi.go
+++ b/cmdapi/cmdapi.go
@@ -1,0 +1,12 @@
+package cmdapi
+
+var Comms = map[string]map[string][]string{
+	"jeep": map[string][]string{
+		"s": []string{"CMD010", "CMD020"},
+		"w": []string{"CMD010", "CMD020", "CMD012", "CMD022"},
+		"a": []string{"CMD010", "CMD020", "CMD012", "CMD122"},
+		"d": []string{"CMD010", "CMD020", "CMD112", "CMD022"},
+		"x": []string{"CMD010", "CMD020", "CMD112", "CMD122"},
+		"l": []string{"CMDLOK"},
+	},
+}

--- a/commands/connect/connect.go
+++ b/commands/connect/connect.go
@@ -3,21 +3,11 @@ package connect
 import (
 	"bufio"
 	"fmt"
+	"github.com/smart-evolution/smarthome-cli/cmdapi"
 	"net"
 	"os"
 	"strings"
 )
-
-var comms = map[string]map[string][]string{
-	"jeep": map[string][]string{
-		"s": []string{"CMD010", "CMD020"},
-		"w": []string{"CMD010", "CMD020", "CMD012", "CMD022"},
-		"a": []string{"CMD010", "CMD020", "CMD012", "CMD122"},
-		"d": []string{"CMD010", "CMD020", "CMD112", "CMD022"},
-		"x": []string{"CMD010", "CMD020", "CMD112", "CMD122"},
-		"l": []string{"CMDLOK"},
-	},
-}
 
 func Handler() {
 	var device string
@@ -53,7 +43,7 @@ func Handler() {
 
 	devType := string(buff[:n])
 
-	if _, ok := comms[devType]; !ok {
+	if _, ok := cmdapi.Comms[devType]; !ok {
 		fmt.Println("unknown device type '" + devType + "'")
 		os.Exit(1)
 	}
@@ -72,7 +62,7 @@ func Handler() {
 			break
 		}
 
-		hardwareComms := comms[devType][cmd]
+		hardwareComms := cmdapi.Comms[devType][cmd]
 
 		for _, c := range hardwareComms {
 			_, err = conn.Write([]byte(c))

--- a/commands/proxy/proxy.go
+++ b/commands/proxy/proxy.go
@@ -3,22 +3,12 @@ package proxy
 import (
 	"bufio"
 	"fmt"
+	"github.com/smart-evolution/smarthome-cli/cmdapi"
 	"github.com/smart-evolution/smarthome-cli/utils"
 	"net"
 	"os"
 	"strings"
 )
-
-var comms = map[string]map[string][]string{
-	"jeep": map[string][]string{
-		"s": []string{"CMD010", "CMD020"},
-		"w": []string{"CMD010", "CMD020", "CMD012", "CMD022"},
-		"a": []string{"CMD010", "CMD020", "CMD012", "CMD122"},
-		"d": []string{"CMD010", "CMD020", "CMD112", "CMD022"},
-		"x": []string{"CMD010", "CMD020", "CMD112", "CMD122"},
-		"l": []string{"CMDLOK"},
-	},
-}
 
 func Handler() {
 	conn, err := net.Dial("tcp", os.Getenv("SMARTHOME_CLI_SRV"))
@@ -60,7 +50,7 @@ func Handler() {
 			break
 		}
 
-		hardwareComms := comms[devType][cmd]
+		hardwareComms := cmdapi.Comms[devType][cmd]
 
 		for _, c := range hardwareComms {
 			_, err = conn.Write([]byte(c))

--- a/commands/proxy/proxy.go
+++ b/commands/proxy/proxy.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/smart-evolution/smarthome-cli/utils"
+	"net"
+	"os"
+	"strings"
+)
+
+var comms = map[string]map[string][]string{
+	"jeep": map[string][]string{
+		"s": []string{"CMD010", "CMD020"},
+		"w": []string{"CMD010", "CMD020", "CMD012", "CMD022"},
+		"a": []string{"CMD010", "CMD020", "CMD012", "CMD122"},
+		"d": []string{"CMD010", "CMD020", "CMD112", "CMD022"},
+		"x": []string{"CMD010", "CMD020", "CMD112", "CMD122"},
+		"l": []string{"CMDLOK"},
+	},
+}
+
+func Handler() {
+	conn, err := net.Dial("tcp", os.Getenv("SMARTHOME_CLI_SRV"))
+
+	if err != nil {
+		fmt.Println("error connecting to the smarthome cli server")
+		os.Exit(1)
+	}
+
+	var device string
+	if len(os.Args) > 2 {
+		device = os.Args[2]
+	} else {
+		fmt.Println("device address required")
+		os.Exit(1)
+	}
+
+	buff := make([]byte, 512)
+	msg := utils.MsgConstructor("proxy", device)
+	_, err = conn.Write(msg)
+	n, err := conn.Read(buff)
+
+	if err != nil {
+		fmt.Println("error reading cli message")
+	}
+
+	devType := string(buff[:n])
+	fmt.Println("connected to device type '" + devType + "'")
+	resBuff := make([]byte, 512)
+
+	for {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print("CMD: ")
+		input, _ := reader.ReadString('\n')
+		cmd := strings.TrimSpace(input)
+
+		if cmd == "disconnect" {
+			conn.Close()
+			break
+		}
+
+		hardwareComms := comms[devType][cmd]
+
+		for _, c := range hardwareComms {
+			_, err = conn.Write([]byte(c))
+			if err != nil {
+				fmt.Println("RES: sending command failed " + c)
+				break
+			}
+
+			if c == "CMDLOK" {
+				n, err := conn.Read(resBuff)
+
+				if err != nil {
+					fmt.Println("RES: error reading message from device")
+					break
+				}
+
+				response := string(resBuff[:n])
+				fmt.Println(response)
+			}
+		}
+	}
+}

--- a/commands/status/status.go
+++ b/commands/status/status.go
@@ -16,7 +16,7 @@ func Handler() {
 	}
 
 	buff := make([]byte, 512)
-	msg := utils.MsgConstructor("status")
+	msg := utils.MsgConstructor("status", "")
 	_, err = conn.Write(msg)
 	n, err := conn.Read(buff)
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/smart-evolution/smarthome-cli/commands/connect"
 	"github.com/smart-evolution/smarthome-cli/commands/default"
+	"github.com/smart-evolution/smarthome-cli/commands/proxy"
 	"github.com/smart-evolution/smarthome-cli/commands/scan"
 	"github.com/smart-evolution/smarthome-cli/commands/send"
 	"github.com/smart-evolution/smarthome-cli/commands/status"
@@ -27,12 +28,14 @@ func main() {
 	switch cmd {
 	case "connect":
 		connect.Handler()
+	case "scan":
+		scan.Handler()
 	case "send":
 		send.Handler()
 	case "status":
 		status.Handler()
-	case "scan":
-		scan.Handler()
+	case "proxy":
+		proxy.Handler()
 	case "version":
 		version.Handler()
 	default:

--- a/utils/msgconstructor.go
+++ b/utils/msgconstructor.go
@@ -1,9 +1,7 @@
 package utils
 
-func MsgConstructor(cmd string) []byte {
-	msgString := `{
-        "cmd": "` + cmd + `"
-    }`
+func MsgConstructor(cmd string, param string) []byte {
+	msgString := `{"cmd": "` + cmd + `","param": "` + param + `"}`
 
 	return []byte(msgString)
 }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/57wnLR9a/128-home-128-add-external-connect-command

**Description:** Sometimes users might want to connect to their home devices from outside of the internal network. Smarthome CLI server should handle `proxy` command to take control over those devices and smarthome-cli should have this possibility implemented.

**Related PRs:**
* https://github.com/smart-evolution/smarthome/pull/60