### PR TITLE
HOME-134 - Closing connections to clients doesn't work

### DIFF
--- a/cmdapi/cmdapi.go
+++ b/cmdapi/cmdapi.go
@@ -2,11 +2,12 @@ package cmdapi
 
 var Comms = map[string]map[string][]string{
 	"jeep": map[string][]string{
-		"s": []string{"CMD010", "CMD020"},
-		"w": []string{"CMD010", "CMD020", "CMD012", "CMD022"},
-		"a": []string{"CMD010", "CMD020", "CMD012", "CMD122"},
-		"d": []string{"CMD010", "CMD020", "CMD112", "CMD022"},
-		"x": []string{"CMD010", "CMD020", "CMD112", "CMD122"},
-		"l": []string{"CMDLOK"},
+		"s":          []string{"CMD010", "CMD020"},
+		"w":          []string{"CMD010", "CMD020", "CMD012", "CMD022"},
+		"a":          []string{"CMD010", "CMD020", "CMD012", "CMD122"},
+		"d":          []string{"CMD010", "CMD020", "CMD112", "CMD022"},
+		"x":          []string{"CMD010", "CMD020", "CMD112", "CMD122"},
+		"l":          []string{"CMDLOK"},
+		"disconnect": []string{"CMDDIS"},
 	},
 }

--- a/commands/connect/connect.go
+++ b/commands/connect/connect.go
@@ -72,13 +72,13 @@ func Handler() {
 				if err != nil {
 					fmt.Println("RES: error reading message from device")
 					break
-				} else if c == "CMDDIS" {
-					conn.Close()
-					os.Exit(0)
 				}
 
 				response := string(resBuff[:n])
 				fmt.Println(response)
+			} else if c == "CMDDIS" {
+				conn.Close()
+				os.Exit(0)
 			}
 		}
 	}

--- a/commands/connect/connect.go
+++ b/commands/connect/connect.go
@@ -57,11 +57,6 @@ func Handler() {
 		input, _ := reader.ReadString('\n')
 		cmd := strings.TrimSpace(input)
 
-		if cmd == "disconnect" {
-			conn.Close()
-			break
-		}
-
 		hardwareComms := cmdapi.Comms[devType][cmd]
 
 		for _, c := range hardwareComms {
@@ -77,6 +72,9 @@ func Handler() {
 				if err != nil {
 					fmt.Println("RES: error reading message from device")
 					break
+				} else if c == "CMDDIS" {
+					conn.Close()
+					os.Exit(0)
 				}
 
 				response := string(resBuff[:n])

--- a/commands/proxy/proxy.go
+++ b/commands/proxy/proxy.go
@@ -19,6 +19,7 @@ func Handler() {
 	}
 
 	var device string
+
 	if len(os.Args) > 2 {
 		device = os.Args[2]
 	} else {
@@ -45,11 +46,6 @@ func Handler() {
 		input, _ := reader.ReadString('\n')
 		cmd := strings.TrimSpace(input)
 
-		if cmd == "disconnect" {
-			conn.Close()
-			break
-		}
-
 		hardwareComms := cmdapi.Comms[devType][cmd]
 
 		for _, c := range hardwareComms {
@@ -69,6 +65,9 @@ func Handler() {
 
 				response := string(resBuff[:n])
 				fmt.Println(response)
+			} else if c == "CMDDIS" {
+				conn.Close()
+				os.Exit(0)
 			}
 		}
 	}


### PR DESCRIPTION
**Business justification:** HOME-134 - Closing connections to clients doesn't work

**Description:** When user was connected to the device via smarthome-cli and killed the connection from the CLI point of view, hardware was still 'thinking' it was connected. This PR creates a command that can be sent to container in channel 0 to close the connection.

**Related PRs:**
* https://github.com/smart-evolution/smart-home-uc/pull/5
* https://github.com/smart-evolution/smarthome-cli/pull/10
* https://github.com/smart-evolution/smarthome/pull/61
* https://github.com/smart-evolution/smart-home-agent-esp8266/pull/5