### PR TITLE
HOME-135 - Improve devices scanning

### DIFF
--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -4,39 +4,49 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"time"
 )
 
 var addrs []string
 
-func Handler() {
-	for i := 1; i <= 255; i++ {
-		fmt.Print("\033[H\033[2J")
-		addr := "192.168.1." + strconv.Itoa(i)
-		fmt.Println("checking " + strconv.Itoa(i) + " address out of 255")
+func scan(wg *sync.WaitGroup, ip string) {
+	defer wg.Done()
+	//		fmt.Print("\033[H\033[2J")
+	//		fmt.Println("checking " + strconv.Itoa(i) + " address out of 255")
 
-		d := net.Dialer{Timeout: time.Duration(500) * time.Millisecond}
-		conn, err := d.Dial("tcp", addr+":81")
-		if err != nil {
-			continue
-		}
-
-		_, err = conn.Write([]byte("CMDWHO"))
-
-		if err != nil {
-			continue
-		}
-
-		buff := make([]byte, 512)
-		n, err := conn.Read(buff)
-
-		if err != nil {
-			continue
-		}
-
-		devType := string(buff[:n])
-		addrs = append(addrs, addr+"::"+devType)
+	d := net.Dialer{Timeout: time.Duration(1000) * time.Millisecond}
+	conn, err := d.Dial("tcp", ip + ":81")
+	if err != nil {
+		return
 	}
+
+	_, err = conn.Write([]byte("CMDWHO"))
+
+	if err != nil {
+		return
+	}
+
+	buff := make([]byte, 512)
+	n, err := conn.Read(buff)
+
+	if err != nil {
+		return
+	}
+
+	devType := string(buff[:n])
+	addrs = append(addrs, ip+"::"+devType)
+}
+
+func Handler() {
+	var wg sync.WaitGroup
+
+	for i := 1; i <= 255; i++ {
+		ip := "192.168.1." + strconv.Itoa(i)
+		wg.Add(1)
+		go scan(&wg, ip)
+	}
+	wg.Wait()
 
 	fmt.Println(strconv.Itoa(len(addrs)) + " compliant devices found")
 	for _, dev := range addrs {

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -16,12 +16,14 @@ func scan(wg *sync.WaitGroup, ip string) {
 	d := net.Dialer{Timeout: time.Duration(1000) * time.Millisecond}
 	conn, err := d.Dial("tcp", ip+":81")
 	if err != nil {
+		fmt.Println("error dialing to " + ip)
 		return
 	}
 
 	_, err = conn.Write([]byte("CMDWHO"))
 
 	if err != nil {
+		fmt.Println("error seinding CMDWHO to " + ip)
 		return
 	}
 
@@ -29,6 +31,7 @@ func scan(wg *sync.WaitGroup, ip string) {
 	n, err := conn.Read(buff)
 
 	if err != nil {
+		fmt.Println("error reading CMDWHO response from " + ip)
 		return
 	}
 

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -12,11 +12,9 @@ var addrs []string
 
 func scan(wg *sync.WaitGroup, ip string) {
 	defer wg.Done()
-	//		fmt.Print("\033[H\033[2J")
-	//		fmt.Println("checking " + strconv.Itoa(i) + " address out of 255")
 
 	d := net.Dialer{Timeout: time.Duration(1000) * time.Millisecond}
-	conn, err := d.Dial("tcp", ip + ":81")
+	conn, err := d.Dial("tcp", ip+":81")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
**Business justification:** https://trello.com/c/5FBRpxJA/135-home-135-improve-devices-scanning

**Description:** For now scanning for devices takes long time (0.5 sec per device). Why not to use GOLANG advantages and scan devices parallelly. This PR makes sure we're looking for devices in parallel way rather than one by one.

Also side effect of this changes is that we can give every device more time to respond (1 sec instead of 0.5) to send back handshake command.